### PR TITLE
add missing dependency

### DIFF
--- a/api/pyproject.toml
+++ b/api/pyproject.toml
@@ -15,4 +15,5 @@ dependencies = [
     "asyncstdlib>=3.13.0",
     "ujson>=5.10.0",
     "asgiref>=3.8.1",
+    "curl_cffi"
 ]


### PR DESCRIPTION
curl_cffi was missing in the pyproject.toml